### PR TITLE
fix bug about scipy solver

### DIFF
--- a/flopt/solvers/scipy_search.py
+++ b/flopt/solvers/scipy_search.py
@@ -1,6 +1,6 @@
 from time import time
 
-import scipy
+from scipy import optimize as scipy_optimize
 import numpy as np
 
 from flopt.solvers.base import BaseSearch
@@ -75,7 +75,7 @@ class ScipySearch(BaseSearch):
         # bounds
         lb = [var.lowBound for var in self.solution]
         ub = [var.upBound for var in self.solution]
-        bounds = scipy.optimize.Bounds(lb, ub, keep_feasible=False)
+        bounds = scipy_optimize.Bounds(lb, ub, keep_feasible=False)
 
         # constraints
         constraints = []
@@ -87,7 +87,7 @@ class ScipySearch(BaseSearch):
             elif const.type == 'ge':
                 ub = np.inf
             nonlinear_const = \
-                scipy.optimize.NonlinearConstraint(const_func, lb, ub)
+                scipy_optimize.NonlinearConstraint(const_func, lb, ub)
             constraints.append(nonlinear_const)
 
         # options
@@ -111,7 +111,7 @@ class ScipySearch(BaseSearch):
                 _callback([self.solution], self.best_solution, self.best_obj_value)
 
         try:
-            res = scipy.optimize.minimize(
+            res = scipy_optimize.minimize(
                 func, x0, bounds=bounds, constraints=constraints, options=options,
                 callback=callback, args=(), method=self.method,
                 jac=None, hess=None, hessp=None, tol=None,


### PR DESCRIPTION
fix bug about

```python
from flopt import Variable, Problem, Solver

# Variables
a = Variable('a', lowBound=0, upBound=1, cat='Integer')
b = Variable('b', lowBound=1, upBound=2, cat='Continuous')
c = Variable('c', lowBound=1, upBound=3, cat='Continuous')

# 1. Minimize
# in this case optimal solution (a, b, c) = (0, 1, 1), and objective value = 5
prob = Problem(name='Test')
prob += 2*(3*a+b)*c**2+3

# Solver
solver = Solver(algo='ScipySearch')
solver.setParams(timelimit=5)  # setting of the hyper parameters
status, log = prob.solve(solver, msg=True)    # run solver to solve the problem
```


```
Welcome to the flopt Solver
Version 0.3
Date: July 3, 2021

Algorithm: ScipySearch
Params: {'timelimit': 5}
Number of variables 3 (continuous 2 , int 1, binary 0, permutation 0 (0))


     Trial Incumbent    BestBd  Gap[%] Time[s]
----------------------------------------------
S        0    15.000         -       -    0.00
Traceback (most recent call last):
  File "/Users/tateiwanariaki/Documents/myflopt/flopt/example_simple.py", line 28, in <module>
    status, log = prob.solve(solver, msg=True)    # run solver to solve the problem
  File "/Users/tateiwanariaki/Documents/myflopt/flopt/flopt/problem.py", line 145, in solve
    status, log, self.time = solver.solve(
  File "/Users/tateiwanariaki/Documents/myflopt/flopt/flopt/solvers/base.py", line 152, in solve
    status = self.search()
  File "/Users/tateiwanariaki/Documents/myflopt/flopt/flopt/solvers/scipy_search.py", line 50, in search
    status = self._search()
  File "/Users/tateiwanariaki/Documents/myflopt/flopt/flopt/solvers/scipy_search.py", line 78, in _search
    bounds = scipy.optimize.Bounds(lb, ub, keep_feasible=False)
AttributeError: module 'scipy' has no attribute 'optimize'
```